### PR TITLE
[MRG] Tokenization and image preprocessing capabilities for VisDial test split.

### DIFF
--- a/data/prepro.py
+++ b/data/prepro.py
@@ -83,9 +83,10 @@ def create_data_mats(data_toks, ques_inds, ans_inds, params, dtype):
     max_cap_len = params.max_cap_len
     captions = np.zeros([num_threads, max_cap_len])
     caption_len = np.zeros(num_threads, dtype=np.int)
-    
+    image_ids = list(data_toks.keys())
+
     for i in range(num_threads):
-        image_id = list(data_toks.keys())[i]
+        image_id = image_ids[i]
         if dtype == 'test':
             image_list.append('test2017/VisualDialog_test2017_%012d.jpg' % (image_id))
         else:
@@ -105,7 +106,7 @@ def create_data_mats(data_toks, ques_inds, ans_inds, params, dtype):
 
     # create questions and answers data mats
     for i in range(num_threads):
-        image_id = list(data_toks.keys())[i]
+        image_id = image_ids[i]
         for j in range(num_rounds):
             if data_toks[image_id]['dialog'][j]['question'] != -1:
                 question_len[i][j] = len(ques_inds[data_toks[image_id]['dialog'][j]['question']][0:max_ques_len])
@@ -124,8 +125,9 @@ def create_data_mats(data_toks, ques_inds, ans_inds, params, dtype):
         options = np.zeros([num_threads, num_rounds, 100])
 
     for i in range(num_threads):
-        image_id = list(data_toks.keys())[i]
+        image_id = image_ids[i]
         for j in range(num_rounds):
+            # options and answer_index are 1-indexed specifically for lua
             if dtype == 'test':
                 num_rounds_list[i] = data_toks[image_id]['num_rounds']
                 if j == num_rounds_list[i] - 1:

--- a/data/prepro.py
+++ b/data/prepro.py
@@ -12,7 +12,7 @@ def tokenize_data(data, word_count=False):
     '''
     res, word_counts = {}, {}
 
-    print data['split']
+    print 'Tokenizing data for %s...' % data['split']
     print 'Tokenizing captions...'
     for i in data['data']['dialogs']:
         img_id = i['image_id']
@@ -28,11 +28,14 @@ def tokenize_data(data, word_count=False):
         ans_toks.append(word_tokenize(i))
 
     for i in data['data']['dialogs']:
+        # pad i['dialog'] with NoneType question-answer pairs in the beginning
+        while len(i['dialog']) < 10:
+            i['dialog'].insert(0, {'question': None, 'answer': None})
         res[i['image_id']]['dialog'] = i['dialog']
-        for j in range(10):
-            question = ques_toks[i['dialog'][j]['question']]
-            answer = ans_toks[i['dialog'][j]['answer']]
-            if word_count == True:
+        if word_count == True:
+            for j in range(10):
+                question = ques_toks[i['dialog'][j]['question']]
+                answer = ans_toks[i['dialog'][j]['answer']]
                 for word in question + answer:
                     word_counts[word] = word_counts.get(word, 0) + 1
 
@@ -117,6 +120,7 @@ if __name__ == "__main__":
     # Input files
     parser.add_argument('-input_json_train', default='visdial_0.9_train.json', help='Input `train` json file')
     parser.add_argument('-input_json_val', default='visdial_0.9_val.json', help='Input `val` json file')
+    parser.add_argument('-input_json_test', default='visdial_0.9_test.json', help='Input `test` json file')
 
     # Output files
     parser.add_argument('-output_json', default='visdial_params.json', help='Output json file')
@@ -140,10 +144,15 @@ if __name__ == "__main__":
     print 'Reading json...'
     data_train = json.load(open(args.input_json_train, 'r'))
     data_val = json.load(open(args.input_json_val, 'r'))
+    data_test = None
+    if os.path.exists(args.input_json_test):
+        data_test = json.load(open(args.input_json_test, 'r'))
 
     # Tokenizing
     data_train_toks, ques_train_toks, ans_train_toks, word_counts_train = tokenize_data(data_train, True)
     data_val_toks, ques_val_toks, ans_val_toks, _ = tokenize_data(data_val)
+    if data_test:
+        data_test_toks, ques_test_toks, ans_test_toks, _ = tokenize_data(data_test)
 
     print 'Building vocabulary...'
     word_counts_train['UNK'] = args.word_count_threshold

--- a/data/prepro_utils.lua
+++ b/data/prepro_utils.lua
@@ -36,6 +36,11 @@ function extractFeatures(model, opt, ndims, preprocessFn)
         table.insert(valList, string.format('%s/val2014/COCO_val2014_%012d.jpg', opt.imageRoot, imName))
     end
 
+    local testList = {}
+    for i, imName in pairs(jsonFile.unique_img_test) do
+        table.insert(valList, string.format('%s/test2015/COCO_test2015_%012d.jpg', opt.imageRoot, imName))
+    end
+
     local sz = #trainList
     local trainFeats = torch.FloatTensor(sz, unpack(ndims))
     -- feature_dims shall be either 2 (NW format), else 4 (having NCHW format)
@@ -90,8 +95,34 @@ function extractFeatures(model, opt, ndims, preprocessFn)
         collectgarbage()
     end
 
+    local sz = #testList
+    local testFeats = torch.FloatTensor(sz, unpack(ndims))
+    print(string.format('Processing %d test images...', sz))
+    for i = 1, sz, opt.batchSize do
+        xlua.progress(i, sz)
+        r = math.min(sz, i + opt.batchSize - 1)
+        ims = torch.DoubleTensor(r - i + 1, 3, opt.imgSize, opt.imgSize)
+        for j = 1, r - i + 1 do
+            ims[j] = loadImage(valList[i + j - 1], opt.imgSize)
+            ims[j] = preprocessFn(ims[j])
+        end
+        if opt.gpuid >= 0 then
+            ims = ims:cuda()
+        end
+
+        if feature_dims == 4 then
+            -- forward pass and permute to get NHWC format
+            model:forward(ims):permute(1, 3, 4, 2):contiguous():float()
+        else
+            model:forward(ims)
+        end
+        testFeats[{{i, r}, {}}] = model.output:float()
+        collectgarbage()
+    end
+
     local h5File = hdf5.open(opt.outName, 'w')
     h5File:write('/images_train', trainFeats)
     h5File:write('/images_val', valFeats)
+    h5File:write('/images_test', testFeats)
     h5File:close()
 end

--- a/data/prepro_utils.lua
+++ b/data/prepro_utils.lua
@@ -20,38 +20,38 @@ function loadImage(imageName, imgSize, preprocessType)
     return im
 end
 
-function extractFeatures(model, opt, ndims, preprocessFn)
+function extractFeaturesSplit(model, opt, ndims, preprocessFn, split)
     local file = io.open(opt.inputJson, 'r')
     local text = file:read()
     file:close()
     jsonFile = cjson.decode(text)
 
-    local trainList = {}
-    for i, imName in pairs(jsonFile.unique_img_train) do
-        table.insert(trainList, string.format('%s/train2014/COCO_train2014_%012d.jpg', opt.imageRoot, imName))
+    local imList = {}
+    if split == 'train' do
+        for i, imName in pairs(jsonFile.unique_img_train) do
+            table.insert(trainList, string.format('%s/train2014/COCO_train2014_%012d.jpg', opt.imageRoot, imName))
+        end
+    elseif split == 'val' do
+        for i, imName in pairs(jsonFile.unique_img_val) do
+            table.insert(valList, string.format('%s/val2014/COCO_val2014_%012d.jpg', opt.imageRoot, imName))
+        end
+    else
+        for i, imName in pairs(jsonFile.unique_img_test) do
+            table.insert(valList, string.format('%s/test2015/COCO_test2015_%012d.jpg', opt.imageRoot, imName))
+        end
     end
 
-    local valList = {}
-    for i, imName in pairs(jsonFile.unique_img_val) do
-        table.insert(valList, string.format('%s/val2014/COCO_val2014_%012d.jpg', opt.imageRoot, imName))
-    end
-
-    local testList = {}
-    for i, imName in pairs(jsonFile.unique_img_test) do
-        table.insert(valList, string.format('%s/test2015/COCO_test2015_%012d.jpg', opt.imageRoot, imName))
-    end
-
-    local sz = #trainList
-    local trainFeats = torch.FloatTensor(sz, unpack(ndims))
+    local sz = #imList
+    local imFeats = torch.FloatTensor(sz, unpack(ndims))
     -- feature_dims shall be either 2 (NW format), else 4 (having NCHW format)
-    local feature_dims = #trainFeats:size()  
-    print(string.format('Processing %d train images...', sz))
+    local feature_dims = #imFeats:size()  
+    print(string.format('Processing %d %s images...', sz, split))
     for i = 1, sz, opt.batchSize do
         xlua.progress(i, sz)
         r = math.min(sz, i + opt.batchSize - 1)
         ims = torch.DoubleTensor(r - i + 1, 3, opt.imgSize, opt.imgSize)
         for j = 1, r - i + 1 do
-            ims[j] = loadImage(trainList[i + j - 1], opt.imgSize)
+            ims[j] = loadImage(imList[i + j - 1], opt.imgSize)
             ims[j] = preprocessFn(ims[j])
         end
         if opt.gpuid >= 0 then
@@ -64,65 +64,18 @@ function extractFeatures(model, opt, ndims, preprocessFn)
         else
             model:forward(ims)
         end
-        trainFeats[{{i, r}, {}}] = model.output:float()
+        imFeats[{{i, r}, {}}] = model.output:float()
         collectgarbage()
     end
-
     print('\n')
 
-    local sz = #valList
-    local valFeats = torch.FloatTensor(sz, unpack(ndims))
-    print(string.format('Processing %d val images...', sz))
-    for i = 1, sz, opt.batchSize do
-        xlua.progress(i, sz)
-        r = math.min(sz, i + opt.batchSize - 1)
-        ims = torch.DoubleTensor(r - i + 1, 3, opt.imgSize, opt.imgSize)
-        for j = 1, r - i + 1 do
-            ims[j] = loadImage(valList[i + j - 1], opt.imgSize)
-            ims[j] = preprocessFn(ims[j])
-        end
-        if opt.gpuid >= 0 then
-            ims = ims:cuda()
-        end
-
-        if feature_dims == 4 then
-            -- forward pass and permute to get NHWC format
-            model:forward(ims):permute(1, 3, 4, 2):contiguous():float()
-        else
-            model:forward(ims)
-        end
-        valFeats[{{i, r}, {}}] = model.output:float()
-        collectgarbage()
-    end
-
-    local sz = #testList
-    local testFeats = torch.FloatTensor(sz, unpack(ndims))
-    print(string.format('Processing %d test images...', sz))
-    for i = 1, sz, opt.batchSize do
-        xlua.progress(i, sz)
-        r = math.min(sz, i + opt.batchSize - 1)
-        ims = torch.DoubleTensor(r - i + 1, 3, opt.imgSize, opt.imgSize)
-        for j = 1, r - i + 1 do
-            ims[j] = loadImage(valList[i + j - 1], opt.imgSize)
-            ims[j] = preprocessFn(ims[j])
-        end
-        if opt.gpuid >= 0 then
-            ims = ims:cuda()
-        end
-
-        if feature_dims == 4 then
-            -- forward pass and permute to get NHWC format
-            model:forward(ims):permute(1, 3, 4, 2):contiguous():float()
-        else
-            model:forward(ims)
-        end
-        testFeats[{{i, r}, {}}] = model.output:float()
-        collectgarbage()
-    end
-
     local h5File = hdf5.open(opt.outName, 'w')
-    h5File:write('/images_train', trainFeats)
-    h5File:write('/images_val', valFeats)
-    h5File:write('/images_test', testFeats)
+    h5File:write(string.format('/images_%s', split), imFeats)
     h5File:close()
+end
+
+function extractFeatures(model, opt, ndims, preprocessFn)
+    extractFeaturesSplit(model, opt, ndims, preprocessFn, 'train')
+    extractFeaturesSplit(model, opt, ndims, preprocessFn, 'val')
+    extractFeaturesSplit(model, opt, ndims, preprocessFn, 'test')
 end


### PR DESCRIPTION
Introduce modifications in preprocessing script (**data/prepro.py**) to enable preprocessing of VisDial _test_ split. Notable differences between _test_ split and _train/val_ split:

1. The dialog might have less than 10 rounds.
2. No ground truth answer for any round of dialog.
  - `visdial['data']['dialogs']['dialog']['gt_index']` is absent
3. 100 candidate answer options available for last round of dialog.
  - `visdial['data']['dialogs']['dialog']['answer_options']` for last round

Dialog is padded with dummy questions and answers in the beginning to complete ten rounds. Options for test split has shape `(num_threads, 100)` instead of `(num_threads, 10, 100)` and it is assumed that they are for the last round.

Changes made in this PR affect in the following manner:
1. **visdial_params.json** has a new list: `unique_images_test`.
2. **visdial_data.h5** has entries for test split similar to train and val splits.
3. **data_img.h5** has a new dataset: `images_test`.
