### PR TITLE
Support evaluation on VisDial test split.

### DIFF
--- a/dataloader.lua
+++ b/dataloader.lua
@@ -46,7 +46,9 @@ function dataloader:initialize(opt, subsets)
         -- read answer related information
         self[dtype..'_ans'] = quesFile:read('ans_'..dtype):all();
         self[dtype..'_ans_len'] = quesFile:read('ans_length_'..dtype):all();
-        self[dtype..'_ans_ind'] = quesFile:read('ans_index_'..dtype):all():long();
+        if dtype ~= 'test' then
+            self[dtype..'_ans_ind'] = quesFile:read('ans_index_'..dtype):all():long();
+        end
 
         -- read image list, if image features are needed
         if opt.useIm then
@@ -97,6 +99,11 @@ function dataloader:initialize(opt, subsets)
             self[dtype..'_opt'] = quesFile:read('opt_'..dtype):all():long();
             self[dtype..'_opt_len'] = quesFile:read('opt_length_'..dtype):all();
             self[dtype..'_opt_list'] = quesFile:read('opt_list_'..dtype):all();
+            self.numOptions = self[dtype..'_opt']:size(3);
+        end
+
+        if dtype == 'test' then
+            self[dtype..'_num_rounds'] = quesFile:read('num_rounds_'..dtype):all();
         end
 
         -- assume similar stats across multiple data subsets
@@ -106,10 +113,6 @@ function dataloader:initialize(opt, subsets)
         self.maxQuesLen = self[dtype..'_ques']:size(3);
         -- maximum length of answer
         self.maxAnsLen = self[dtype..'_ans']:size(3);
-        -- number of options, if read
-        if self[dtype..'_opt'] then
-            self.numOptions = self[dtype..'_opt']:size(3);
-        end
 
         -- if history is needed
         if opt.useHistory then
@@ -178,11 +181,13 @@ function dataloader:processAnswers(dtype)
 
                 decodeOut[thId][roundId][{{1, length}}]
                                 = answers[thId][roundId][{{1, length}}];
-                decodeOut[thId][roundId][length+1] = endTokenId;
             else
-                print(string.format('Warning: empty answer at (%d %d %d)',
-                                                    thId, roundId, length))
+                if dtype ~= 'test' then
+                    print(string.format('Warning: empty answer at (%d %d %d)',
+                                                        thId, roundId, length))
+                end
             end
+            decodeOut[thId][roundId][length+1] = endTokenId;
         end
     end
 
@@ -353,8 +358,10 @@ function dataloader.getTestBatch(self, startId, params, dtype)
     if params.decoder == 'disc' then
         batchOutput['options'] = optionOutput:view(optionOutput:size(1)
                                     * optionOutput:size(2), optionOutput:size(3), -1)
-        batchOutput['answer_ind'] = batchOutput['answer_ind']:view(batchOutput['answer_ind']
-                                        :size(1) * batchOutput['answer_ind']:size(2))
+        if dtype ~= 'test' then 
+            batchOutput['answer_ind'] = batchOutput['answer_ind']:view(batchOutput['answer_ind']
+                                            :size(1) * batchOutput['answer_ind']:size(2))
+        end
     elseif params.decoder == 'gen' then
         -- merge both the tables and return
         for key, value in pairs(optionOutput) do batchOutput[key] = value; end
@@ -394,14 +401,12 @@ function dataloader.getIndexData(self, inds, params, dtype)
                                 :index(1, inds)[{{}, {}, {1, maxAnsLen}}];
     local answerOut = self[dtype..'_ans_out']
                                 :index(1, inds)[{{}, {}, {1, maxAnsLen}}];
-    local answerInd = self[dtype..'_ans_ind']:index(1, inds);
 
     local output = {};
     if params.gpuid >= 0 then
         output['ques_fwd'] = quesFwd:cuda();
         output['answer_in'] = answerIn:cuda();
         output['answer_out'] = answerOut:cuda();
-        output['answer_ind'] = answerInd:cuda();
         if history then output['hist'] = history:cuda(); end
         if caption then output['cap'] = caption:cuda(); end
         if imgFeats then output['img_feat'] = imgFeats:cuda(); end
@@ -409,10 +414,14 @@ function dataloader.getIndexData(self, inds, params, dtype)
         output['ques_fwd'] = quesFwd:contiguous();
         output['answer_in'] = answerIn:contiguous();
         output['answer_out'] = answerOut:contiguous();
-        output['answer_ind'] = answerInd:contiguous()
         if history then output['hist'] = history:contiguous(); end
         if caption then output['cap'] = caption:contiguous(); end
         if imgFeats then output['img_feat'] = imgFeats:contiguous(); end
+    end
+
+    if dtype ~= 'test' then
+        local answerInd = self[dtype..'_ans_ind']:index(1, inds);
+        output['answer_ind'] = params.gpuid >= 0 and answerInd:cuda() or answerInd:contiguous();
     end
 
     return output;

--- a/dataloader.lua
+++ b/dataloader.lua
@@ -361,6 +361,8 @@ function dataloader.getTestBatch(self, startId, params, dtype)
         if dtype ~= 'test' then 
             batchOutput['answer_ind'] = batchOutput['answer_ind']:view(batchOutput['answer_ind']
                                             :size(1) * batchOutput['answer_ind']:size(2))
+        else
+            batchOutput['num_rounds'] = self[dtype..'_num_rounds']:index(1, inds):long()
         end
     elseif params.decoder == 'gen' then
         -- merge both the tables and return
@@ -459,11 +461,24 @@ function dataloader.getIndexOption(self, inds, params, dtype)
     elseif params.decoder == 'disc' then
         local optInds = self[dtype .. '_opt']:index(1, inds)
         local indVector = optInds:view(-1)
-
+    
         local optionIn = self[dtype .. '_opt_list']:index(1, indVector)
 
         optionIn = optionIn:view(optInds:size(1), optInds:size(2), optInds:size(3), -1)
 
+<<<<<<< HEAD
+=======
+        if dtype == 'test' then
+            -- convert optionIn to keep options for n-th (last) round and zeros for other rounds
+            local optionInTest = torch.zeros(optionIn:size(1), 10, optionIn:size(3), optionIn:size(4)):int()
+            local numRounds = self[dtype..'_num_rounds']:index(1, inds):long()
+            for i = 1, numRounds:size(1) do
+                optionInTest[{{i}, {numRounds[i]}}] = optionIn[i]
+            end
+            optionIn = optionInTest
+        end
+
+>>>>>>> 0cc81bc... Make changes in dataloader.lua and model.lua to handle right padded dialog rounds.
         output = optionIn
 
         if params.gpuid >= 0 then

--- a/dataloader.lua
+++ b/dataloader.lua
@@ -491,8 +491,6 @@ function dataloader.getIndexOption(self, inds, params, dtype)
 
         optionIn = optionIn:view(optInds:size(1), optInds:size(2), optInds:size(3), -1)
 
-<<<<<<< HEAD
-=======
         if dtype == 'test' then
             -- convert optionIn to keep options for n-th (last) round and zeros for other rounds
             local optionInTest = torch.zeros(optionIn:size(1), 10, optionIn:size(3), optionIn:size(4)):int()
@@ -503,7 +501,6 @@ function dataloader.getIndexOption(self, inds, params, dtype)
             optionIn = optionInTest
         end
 
->>>>>>> 0cc81bc... Make changes in dataloader.lua and model.lua to handle right padded dialog rounds.
         output = optionIn
 
         if params.gpuid >= 0 then

--- a/dataloader.lua
+++ b/dataloader.lua
@@ -39,6 +39,11 @@ function dataloader:initialize(opt, subsets)
     self.numThreads = {};
 
     for _, dtype in pairs(subsets) do
+        -- convert image ids to numbers
+        for k, v in pairs(dataloader['unique_img_'..dtype]) do
+            dataloader['unique_img_'..dtype][k] = tonumber(string.match(v, '000%d+')) 
+        end
+
         -- read question related information
         self[dtype..'_ques'] = quesFile:read('ques_'..dtype):all();
         self[dtype..'_ques_len'] = quesFile:read('ques_length_'..dtype):all();

--- a/evaluate.lua
+++ b/evaluate.lua
@@ -19,6 +19,7 @@ cmd:option('-inputJson','data/visdial_params.json','json path with info and voca
 
 cmd:option('-loadPath', 'checkpoints/model.t7', 'path to saved model')
 cmd:option('-split', 'val', 'split to evaluate on')
+cmd:option('-useGt', false, 'whether to use ground truth for retrieving ranks')
 
 -- Inference params
 cmd:option('-batchSize', 30, 'Batch size (number of threads) (Adjust base on GRAM)')
@@ -29,6 +30,11 @@ cmd:option('-saveRanks', false, 'Whether to save ranks or not');
 cmd:option('-saveRankPath', 'logs/ranks.json');
 
 local opt = cmd:parse(arg);
+
+if opt.useGt and opt.split == 'test' then
+    print('Warning: No ground truth avaiilable in test split, changing useGt to false.')
+    opt.useGt = false
+end
 print(opt)
 
 -- seed for reproducibility
@@ -91,7 +97,7 @@ model.wrapperW:copy(savedModel.modelW);
 -- Evaluation
 ------------------------------------------------------------------------
 print('Evaluating..')
-local retrieval = model:retrieve(dataloader, opt.split);
+local retrieval = model:retrieve(dataloader, opt.split, opt.useGt);
 
 if opt.saveRanks == true then
     print(string.format('Writing ranks to %s', opt.saveRankPath));

--- a/evaluate.lua
+++ b/evaluate.lua
@@ -97,9 +97,14 @@ model.wrapperW:copy(savedModel.modelW);
 -- Evaluation
 ------------------------------------------------------------------------
 print('Evaluating..')
-local retrieval = model:retrieve(dataloader, opt.split, opt.useGt);
+local ranks;
+if opt.useGt then
+    ranks = model:retrieve(dataloader, opt.split);
+else
+    ranks = model:predict(dataloader, opt.split);
+end
 
 if opt.saveRanks == true then
     print(string.format('Writing ranks to %s', opt.saveRankPath));
-    utils.writeJSON(opt.saveRankPath, retrieval);
+    utils.writeJSON(opt.saveRankPath, ranks);
 end

--- a/evaluate.lua
+++ b/evaluate.lua
@@ -91,9 +91,9 @@ model.wrapperW:copy(savedModel.modelW);
 -- Evaluation
 ------------------------------------------------------------------------
 print('Evaluating..')
-local ranks = model:retrieve(dataloader, opt.split);
+local retrieval = model:retrieve(dataloader, opt.split);
 
 if opt.saveRanks == true then
     print(string.format('Writing ranks to %s', opt.saveRankPath));
-    utils.writeJSON(opt.saveRankPath, torch.totable(ranks:double()));
+    utils.writeJSON(opt.saveRankPath, retrieval);
 end

--- a/model.lua
+++ b/model.lua
@@ -222,7 +222,13 @@ function Model:predict(dataloader, dtype)
     local ranks = torch.totable(ranks:double());
     for i = 1, #dataloader['unique_img_'..dtype] do
         -- rank list for all rounds in val split and last round in test split
-        if dtype == 'val' then
+        if dtype == 'test' then
+            table.insert(prediction, {
+                image_id = dataloader['unique_img_'..dtype][i];
+                round_id = dataloader[dtype..'_num_rounds'][i];
+                ranks = ranks[i][dataloader[dtype..'_num_rounds'][i]]
+            })
+        else
             for j = 1, 10 do
                 table.insert(prediction, {
                     image_id = dataloader['unique_img_'..dtype][i];
@@ -230,12 +236,6 @@ function Model:predict(dataloader, dtype)
                     ranks = ranks[i][j]
                 })
             end
-        else
-            table.insert(prediction, {
-                image_id = dataloader['unique_img_'..dtype][i];
-                round_id = dataloader[dtype..'_num_rounds'][i];
-                ranks = ranks[i][dataloader[dtype..'_num_rounds'][i]]
-            })
         end
     end
     -- collect garbage

--- a/utils.lua
+++ b/utils.lua
@@ -104,9 +104,18 @@ end
 -- process the scores and obtain the ranks
 -- input: scores for all options, ground truth positions
 function utils.computeRanks(scores, gtPos)
-    local gtScore = scores:gather(2, gtPos);
-    local ranks = scores:gt(gtScore:expandAs(scores));
-    ranks = ranks:sum(2) + 1;
+    -- simply sort according to scores if ground truth not available
+    local ranks;
+    if gtPos == nil then
+        sorted, ranks = scores:sort(2)
+        for i = 1, scores:size(1) do
+            ranks[i] = ranks[i]:index(1, ranks[i]);
+        end
+    else
+        local gtScore = scores:gather(2, gtPos);
+        ranks = scores:gt(gtScore:expandAs(scores));
+        ranks = ranks:sum(2) + 1;
+    end
 
     -- convert into double
     return ranks:double();

--- a/utils.lua
+++ b/utils.lua
@@ -106,15 +106,16 @@ end
 function utils.computeRanks(scores, gtPos)
     -- simply sort according to scores if ground truth not available
     local ranks;
-    if gtPos == nil then
+    if gtPos then
+        gtPos = gtPos:view(-1, 1);
+        local gtScore = scores:gather(2, gtPos);
+        ranks = scores:gt(gtScore:expandAs(scores));
+        ranks = ranks:sum(2) + 1;
+    else
         sorted, ranks = scores:sort(2)
         for i = 1, scores:size(1) do
             ranks[i] = ranks[i]:index(1, ranks[i]);
         end
-    else
-        local gtScore = scores:gather(2, gtPos);
-        ranks = scores:gt(gtScore:expandAs(scores));
-        ranks = ranks:sum(2) + 1;
     end
 
     -- convert into double

--- a/utils.lua
+++ b/utils.lua
@@ -112,10 +112,8 @@ function utils.computeRanks(scores, gtPos)
         ranks = scores:gt(gtScore:expandAs(scores));
         ranks = ranks:sum(2) + 1;
     else
-        sorted, ranks = scores:sort(2)
-        for i = 1, scores:size(1) do
-            ranks[i] = ranks[i]:index(1, ranks[i]);
-        end
+        -- sort in descending order - largest score gets highest rank
+        sorted, ranks = scores:sort(2, true)
     end
 
     -- convert into double


### PR DESCRIPTION
This PR makes changes in **evaluate.lua** and underlying modifications to dataloader and model files to perform evaluation on test split of VisDial. The schema of test split is described in description of #16 

100 candidate answer options of the dialog round are ranked according to the likelihood in absence of ground truth answer (in test split). The retrieved ranks table in **evaluate.lua** can be saved as a json file (list of json objects, where each object has three keys:

```text
{
    'image_id': 823457, // integer image id from the dataset
    'ranks' : [....], // list of 100 integers, n-th number is rank of n-th candidate answer option
    'round_id': 4 // any integer between 1 to 10
}
```

* For the val split, to get such JSON, `-useGt` flag must be set to false -- setting it to true uses the ground truth answers from the dataset and hence `ranks` comes out to be a single integer, meaning the rank of ground truth. `-UseGt` is set to false forcefully for test split.

* There shall be one such JSON object per image_id for test split, since only ranks of last dialog round are retrieved, whereas there shall be ten such JSON objects for val split, since ranks of all rounds are retrieved.