### PR TITLE
Bug fix / refactor: word count and hardcoded sizes in encoders.

### DIFF
--- a/data/prepro.py
+++ b/data/prepro.py
@@ -19,6 +19,9 @@ def tokenize_data(data, word_count=False):
         img_id = i['image_id']
         caption = word_tokenize(i['caption'])
         res[img_id] = {'caption': caption}
+        if word_count == True:
+            for word in caption:
+                word_counts[word] = word_counts.get(word, 0) + 1
 
     print('Tokenizing questions...')
     ques_toks, ans_toks = [], []
@@ -40,7 +43,7 @@ def tokenize_data(data, word_count=False):
         if word_count == True:
             for j in range(10):
                 question = ques_toks[i['dialog'][j]['question']]
-                answer = ans_toks[i['dialog'][j]['answer']] 
+                answer = ans_toks[i['dialog'][j]['answer']]
                 for word in question + answer:
                     word_counts[word] = word_counts.get(word, 0) + 1
 

--- a/encoders/lf-att-ques-im-hist.lua
+++ b/encoders/lf-att-ques-im-hist.lua
@@ -43,28 +43,34 @@ function encoderNet.model(params)
     local qh = nn.Tanh()(nn.Linear(2*params.rnnHiddenSize, params.rnnHiddenSize)(nn.JoinTable(1,1)({q3,h3})))
 
     -- image attention (inspired by SAN, Yang et al., CVPR16)
-    local img_feat_size = 512
+    local img_feat_size = {1, 14, 14, 512}
     local img_tr_size = params.rnnHiddenSize
     local rnn_size = params.rnnHiddenSize
     local common_embedding_size = 512
     local num_attention_layer = 1
 
     local u = qh
-    local img_tr = nn.Dropout(0.5)(nn.Tanh()(nn.View(-1, 196, img_tr_size)(nn.Linear(img_feat_size, img_tr_size)(nn.View(img_feat_size):setNumInputDims(2)(img_feats)))))
+    local img_tr = nn.Dropout(0.5)(
+                    nn.Tanh()(
+                        nn.View(-1, img_feat_size[2] * img_feat_size[3], img_tr_size)(
+                            nn.Linear(img_feat_size[4], img_tr_size)(
+                                nn.View(img_feat_size[4]):setNumInputDims(2)(img_feats)))))
 
     for i = 1, num_attention_layer do
 
         -- linear layer: 14x14x1024 -> 14x14x512
-        local img_common = nn.View(-1, 196, common_embedding_size)(nn.Linear(img_tr_size, common_embedding_size)(nn.View(-1, img_tr_size)(img_tr)))
+        local img_common = nn.View(-1, img_feat_size[2] * img_feat_size[3], common_embedding_size)(
+                            nn.Linear(img_tr_size, common_embedding_size)(
+                                nn.View(-1, img_tr_size)(img_tr)))
 
         -- replicate lstm state 196 times
         local ques_common = nn.Linear(rnn_size, common_embedding_size)(u)
-        local ques_repl = nn.Replicate(196, 2)(ques_common)
+        local ques_repl = nn.Replicate(img_feat_size[2] * img_feat_size[3], 2)(ques_common)
 
         -- add image and question features (both 196x512)
         local img_ques_common = nn.Dropout(0.5)(nn.Tanh()(nn.CAddTable()({img_common, ques_repl})))
         local h = nn.Linear(common_embedding_size, 1)(nn.View(-1, common_embedding_size)(img_ques_common))
-        local p = nn.SoftMax()(nn.View(-1, 196)(h))
+        local p = nn.SoftMax()(nn.View(-1, img_feat_size[2] * img_feat_size[3])(h))
 
         -- weighted sum of image features
         local p_att = nn.View(1, -1):setNumInputDims(1)(p)

--- a/encoders/lf-ques-hist.lua
+++ b/encoders/lf-ques-hist.lua
@@ -55,7 +55,7 @@ function encoderNet.model(params)
     if dropout > 0 then
         enc:add(nn.Dropout(dropout))
     end
-    enc:add(nn.Linear(2 * params.rnnHiddenSize, 512))
+    enc:add(nn.Linear(2 * params.rnnHiddenSize, params.rnnHiddenSize))
     enc:add(nn.Tanh())
 
     return enc;

--- a/encoders/lf-ques-im-hist.lua
+++ b/encoders/lf-ques-im-hist.lua
@@ -55,7 +55,7 @@ function encoderNet.model(params)
     if dropout > 0 then
         enc:add(nn.Dropout(dropout))
     end
-    enc:add(nn.Linear(2 * params.rnnHiddenSize + params.imgFeatureSize, 512))
+    enc:add(nn.Linear(2 * params.rnnHiddenSize + params.imgFeatureSize, params.rnnHiddenSize))
     enc:add(nn.Tanh())
 
     return enc;

--- a/encoders/lf-ques-im.lua
+++ b/encoders/lf-ques-im.lua
@@ -36,7 +36,7 @@ function encoderNet.model(params)
     if dropout > 0 then
         enc:add(nn.Dropout(dropout))
     end
-    enc:add(nn.Linear(params.rnnHiddenSize + params.imgFeatureSize, 512))
+    enc:add(nn.Linear(params.rnnHiddenSize + params.imgFeatureSize, params.rnnHiddenSize))
     enc:add(nn.Tanh())
 
     return enc;

--- a/encoders/lf-ques.lua
+++ b/encoders/lf-ques.lua
@@ -29,7 +29,7 @@ function encoderNet.model(params)
     if dropout > 0 then
         enc:add(nn.Dropout(dropout))
     end
-    enc:add(nn.Linear(params.rnnHiddenSize, 512))
+    enc:add(nn.Linear(params.rnnHiddenSize, params.rnnHiddenSize))
     enc:add(nn.Tanh())
 
     return enc;

--- a/encoders/mn-att-ques-im-hist.lua
+++ b/encoders/mn-att-ques-im-hist.lua
@@ -65,28 +65,34 @@ function encoderNet.model(params)
     local qh2 = nn.Tanh()(nn.Linear(params.rnnHiddenSize, params.rnnHiddenSize)(nn.CAddTable(){hAttTr, nn.View(-1, params.rnnHiddenSize)(qEmbedView)}))
 
     -- image attention (inspired by SAN, Yang et al., CVPR16)
-    local img_feat_size = 512
+    local img_feat_size = {1, 14, 14, 512}
     local img_tr_size = params.rnnHiddenSize
     local rnn_size = params.rnnHiddenSize
     local common_embedding_size = params.commonEmbeddingSize or 512
     local num_attention_layer = params.numAttentionLayers or 1
 
     local u = qh2
-    local img_tr = nn.Dropout(0.5)(nn.Tanh()(nn.View(-1, 196, img_tr_size)(nn.Linear(img_feat_size, img_tr_size)(nn.View(img_feat_size):setNumInputDims(2)(img_feats)))))
+    local img_tr = nn.Dropout(0.5)(
+                    nn.Tanh()(
+                        nn.View(-1, img_feat_size[2] * img_feat_size[3], img_tr_size)(
+                            nn.Linear(img_feat_size[4], img_tr_size)(
+                                nn.View(img_feat_size[4]):setNumInputDims(2)(img_feats)))))
 
     for i = 1, num_attention_layer do
 
         -- linear layer: 14x14x1024 -> 14x14x512
-        local img_common = nn.View(-1, 196, common_embedding_size)(nn.Linear(img_tr_size, common_embedding_size)(nn.View(-1, img_tr_size)(img_tr)))
+        local img_common = nn.View(-1, img_feat_size[2] * img_feat_size[3], common_embedding_size)(
+                            nn.Linear(img_tr_size, common_embedding_size)(
+                                nn.View(-1, img_tr_size)(img_tr)))
 
         -- replicate lstm state 196 times
         local ques_common = nn.Linear(rnn_size, common_embedding_size)(u)
-        local ques_repl = nn.Replicate(196, 2)(ques_common)
+        local ques_repl = nn.Replicate(img_feat_size[2] * img_feat_size[3], 2)(ques_common)
 
         -- add image and question features (both 196x512)
         local img_ques_common = nn.Dropout(0.5)(nn.Tanh()(nn.CAddTable()({img_common, ques_repl})))
         local h = nn.Linear(common_embedding_size, 1)(nn.View(-1, common_embedding_size)(img_ques_common))
-        local p = nn.SoftMax()(nn.View(-1, 196)(h))
+        local p = nn.SoftMax()(nn.View(-1, img_feat_size[2] * img_feat_size[3])(h))
 
         -- weighted sum of image features
         local p_att = nn.View(1, -1):setNumInputDims(1)(p)

--- a/model.lua
+++ b/model.lua
@@ -259,9 +259,10 @@ function Model:forwardBackward(batch, onlyForward, encOutOnly)
         local imgFeats = batch['img_feat']
         -- if attention, then conv layer features
         if string.match(self.params.encoder, 'att') then
-            imgFeats = imgFeats:view(-1, 1, 14, 14, 512)
+            local imgFeatsSize = imgFeats:size()
+            imgFeats = imgFeats:view(-1, 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1, 1, 1)
-            imgFeats = imgFeats:view(-1, 14, 14, 512)
+            imgFeats = imgFeats:view(-1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
         else
             imgFeats = imgFeats:view(-1, 1, self.params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1)
@@ -351,9 +352,10 @@ function Model:retrieveBatch(batch)
         local imgFeats = batch['img_feat']
         -- if attention, then conv layer features
         if string.match(self.params.encoder, 'att') then
-            imgFeats = imgFeats:view(-1, 1, 14, 14, 512)
+            local imgFeatsSize = imgFeats:size()
+            imgFeats = imgFeats:view(-1, 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1, 1, 1)
-            imgFeats = imgFeats:view(-1, 14, 14, 512)
+            imgFeats = imgFeats:view(-1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
         else
             imgFeats = imgFeats:view(-1, 1, self.params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1)

--- a/model.lua
+++ b/model.lua
@@ -260,9 +260,9 @@ function Model:forwardBackward(batch, onlyForward, encOutOnly)
         -- if attention, then conv layer features
         if string.match(self.params.encoder, 'att') then
             local imgFeatsSize = imgFeats:size()
-            imgFeats = imgFeats:view(-1, 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(imgFeatsSize[1], 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1, 1, 1)
-            imgFeats = imgFeats:view(-1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(imgFeatsSize[1], imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
         else
             imgFeats = imgFeats:view(-1, 1, self.params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1)
@@ -353,9 +353,9 @@ function Model:retrieveBatch(batch)
         -- if attention, then conv layer features
         if string.match(self.params.encoder, 'att') then
             local imgFeatsSize = imgFeats:size()
-            imgFeats = imgFeats:view(-1, 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(imgFeatsSize[1], 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1, 1, 1)
-            imgFeats = imgFeats:view(-1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(imgFeatsSize[1], imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
         else
             imgFeats = imgFeats:view(-1, 1, self.params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1)


### PR DESCRIPTION
- [x] Captions were not used to form word vocabulary in preprocessing, they are used now, along with questions and answers.
- [x] In late fusion encoders, `params.rnnHiddenSize` was hardcoded as 512, which is now replaced accordingly.
- [x] In attention based encoders, size of spatial image features are hardcoded as `14 x 14 x 512`, which are now replaced accordingly.