### PR TITLE
Add imgSpatialSize as a command line opt and add README note.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Similarly, to train a Memory Network model with question, image and history info
 th train.lua -encoder mn-ques-im-hist -decoder disc -gpuid 0
 ```
 
+**Note:** For attention based encoders, set both `imgSpatialSize` and `imgFeatureSize` command line params, feature dimensions are interpreted as `(batch X spatial X spatial X feature)`. For other encoders, `imgSpatialSize` is redundant.
+
 The training script saves model snapshots at regular intervals in the `checkpoints/` folder.
 
 It takes about 15-20 epochs to train models with generative decoding to convergence, and 4-8 epochs for discriminative decoding.

--- a/encoders/lf-att-ques-im-hist.lua
+++ b/encoders/lf-att-ques-im-hist.lua
@@ -43,34 +43,33 @@ function encoderNet.model(params)
     local qh = nn.Tanh()(nn.Linear(2*params.rnnHiddenSize, params.rnnHiddenSize)(nn.JoinTable(1,1)({q3,h3})))
 
     -- image attention (inspired by SAN, Yang et al., CVPR16)
-    local img_feat_size = {1, 14, 14, 512}
     local img_tr_size = params.rnnHiddenSize
     local rnn_size = params.rnnHiddenSize
-    local common_embedding_size = 512
+    local common_embedding_size = params.commonEmbeddingSize
     local num_attention_layer = 1
 
     local u = qh
     local img_tr = nn.Dropout(0.5)(
                     nn.Tanh()(
-                        nn.View(-1, img_feat_size[2] * img_feat_size[3], img_tr_size)(
-                            nn.Linear(img_feat_size[4], img_tr_size)(
-                                nn.View(img_feat_size[4]):setNumInputDims(2)(img_feats)))))
+                        nn.View(-1, params.imgSpatialSize * params.imgSpatialSize, img_tr_size)(
+                            nn.Linear(params.imgFeatureSize, img_tr_size)(
+                                nn.View(params.imgFeatureSize):setNumInputDims(2)(img_feats)))))
 
     for i = 1, num_attention_layer do
 
         -- linear layer: 14x14x1024 -> 14x14x512
-        local img_common = nn.View(-1, img_feat_size[2] * img_feat_size[3], common_embedding_size)(
+        local img_common = nn.View(-1, params.imgSpatialSize * params.imgSpatialSize, common_embedding_size)(
                             nn.Linear(img_tr_size, common_embedding_size)(
                                 nn.View(-1, img_tr_size)(img_tr)))
 
         -- replicate lstm state 196 times
         local ques_common = nn.Linear(rnn_size, common_embedding_size)(u)
-        local ques_repl = nn.Replicate(img_feat_size[2] * img_feat_size[3], 2)(ques_common)
+        local ques_repl = nn.Replicate(params.imgSpatialSize * params.imgSpatialSize, 2)(ques_common)
 
         -- add image and question features (both 196x512)
         local img_ques_common = nn.Dropout(0.5)(nn.Tanh()(nn.CAddTable()({img_common, ques_repl})))
         local h = nn.Linear(common_embedding_size, 1)(nn.View(-1, common_embedding_size)(img_ques_common))
-        local p = nn.SoftMax()(nn.View(-1, img_feat_size[2] * img_feat_size[3])(h))
+        local p = nn.SoftMax()(nn.View(-1, params.imgSpatialSize * params.imgSpatialSize)(h))
 
         -- weighted sum of image features
         local p_att = nn.View(1, -1):setNumInputDims(1)(p)

--- a/evaluate.lua
+++ b/evaluate.lua
@@ -63,6 +63,7 @@ local modelParams = savedModel.modelParams
 -- default values of these opts to load models saved with older version of code
 if not modelParams.weightInit then modelParams.weightInit = 'xavier'; end
 if not modelParams.saveIter then modelParams.saveIter = 2; end
+if not modelParams.imgSpatialSize then modelParams.imgSpatialSize = 14; end
 
 opt.imgNorm = modelParams.imgNorm
 opt.encoder = modelParams.encoder

--- a/model.lua
+++ b/model.lua
@@ -259,10 +259,9 @@ function Model:forwardBackward(batch, onlyForward, encOutOnly)
         local imgFeats = batch['img_feat']
         -- if attention, then conv layer features
         if string.match(self.params.encoder, 'att') then
-            local imgFeatsSize = imgFeats:size()
-            imgFeats = imgFeats:view(imgFeatsSize[1], 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(-1, 1, params.imgSpatialSize, params.imgSpatialSize, params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1, 1, 1)
-            imgFeats = imgFeats:view(imgFeatsSize[1], imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(-1, params.imgSpatialSize, params.imgSpatialSize, params.imgFeatureSize)
         else
             imgFeats = imgFeats:view(-1, 1, self.params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1)
@@ -352,10 +351,9 @@ function Model:retrieveBatch(batch)
         local imgFeats = batch['img_feat']
         -- if attention, then conv layer features
         if string.match(self.params.encoder, 'att') then
-            local imgFeatsSize = imgFeats:size()
-            imgFeats = imgFeats:view(imgFeatsSize[1], 1, imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(-1, 1, params.imgSpatialSize, params.imgSpatialSize, params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1, 1, 1)
-            imgFeats = imgFeats:view(imgFeatsSize[1], imgFeatsSize[2], imgFeatsSize[3], imgFeatsSize[4])
+            imgFeats = imgFeats:view(-1, params.imgSpatialSize, params.imgSpatialSize, params.imgFeatureSize)
         else
             imgFeats = imgFeats:view(-1, 1, self.params.imgFeatureSize)
             imgFeats = imgFeats:repeatTensor(1, self.params.maxQuesCount, 1)

--- a/opts.lua
+++ b/opts.lua
@@ -16,10 +16,11 @@ cmd:option('-imgNorm', 1, 'normalize the image feature. 1=yes, 0=no')
 
 -- model params
 cmd:option('-imgEmbedSize', 300, 'Size of the multimodal embedding')
-cmd:option('-imgFeatureSize', 4096, 'Size of the image feature');
+cmd:option('-imgFeatureSize', 4096, 'Channel size of the image feature')
+cmd:option('-imgSpatialSize', 14, 'Spatial size of image features (for attention-based encoders).')
 cmd:option('-embedSize', 300, 'Size of input word embeddings')
 cmd:option('-rnnHiddenSize', 512, 'Size of the LSTM state')
-cmd:option('-maxHistoryLen', 60, 'Maximum history to consider when using concatenated QA pairs');
+cmd:option('-maxHistoryLen', 60, 'Maximum history to consider when using concatenated QA pairs')
 cmd:option('-numLayers', 2, 'Number of layers in LSTM')
 cmd:option('-commonEmbeddingSize', 512, 'Common embedding size in MN-ATT-QIH')
 cmd:option('-numAttentionLayers', 1, 'No. of attention hops in MN-ATT-QIH')


### PR DESCRIPTION
This command line option is used by attention-based encoders. Works well with `lf-att-ques-im-hist` and `mn-att-ques-im-hist`.