### PR TITLE
Add support in preprocessing script for v1.0 as default.

### DIFF
--- a/data/prepro.py
+++ b/data/prepro.py
@@ -17,7 +17,7 @@ parser.add_argument('-train_split', default='train', help='Choose the data split
 parser.add_argument('-input_json_train', default='visdial_1.0_train.json', help='Input `train` json file')
 parser.add_argument('-input_json_val', default='visdial_1.0_val.json', help='Input `val` json file')
 parser.add_argument('-input_json_test', default='visdial_1.0_test.json', help='Input `test` json file')
-parser.add_argument('-image_root', default='/path/to/images', help='Path to mscoco and VisDial val/test images')
+parser.add_argument('-image_root', default='/path/to/images', help='Path to coco and VisDial val/test images')
 parser.add_argument('-input_vocab', default=False, help='Optional vocab file; similar to visdial_params.json')
 
 # Output files
@@ -189,12 +189,12 @@ if __name__ == "__main__":
 
     if args.download:
         if args.version == '1.0':
-            os.system('wget -O visdial_1.0_train.zip https://www.dropbox.com/s/ix8keeudqrd8hn8/visdial_1.0_train.zip?dl=0')
-            os.system('wget -O visdial_1.0_val.zip https://www.dropbox.com/s/ibs3a0zhw74zisc/visdial_1.0_val.zip?dl=0')
+            os.system('wget https://www.dropbox.com/s/ix8keeudqrd8hn8/visdial_1.0_train.zip')
+            os.system('wget https://www.dropbox.com/s/ibs3a0zhw74zisc/visdial_1.0_val.zip')
         elif args.version == '0.9':
             os.system('wget https://computing.ece.vt.edu/~abhshkdz/data/visdial/visdial_0.9_train.zip')
             os.system('wget https://computing.ece.vt.edu/~abhshkdz/data/visdial/visdial_0.9_val.zip')
-        os.system('wget -O visdial_1.0_test.zip https://www.dropbox.com/s/o7mucbre2zm7i5n/visdial_1.0_test.zip?dl=0')
+        os.system('wget https://www.dropbox.com/s/o7mucbre2zm7i5n/visdial_1.0_test.zip')
 
         os.system('unzip visdial_%s_train.zip' % args.version)
         os.system('unzip visdial_%s_val.zip' % args.version)

--- a/data/prepro.py
+++ b/data/prepro.py
@@ -189,20 +189,20 @@ if __name__ == "__main__":
 
     if args.download:
         if args.version == '1.0':
-            os.system('wget https://www.dropbox.com/s/ix8keeudqrd8hn8/visdial_1.0_train.zip?dl=0')
-            os.system('wget https://www.dropbox.com/s/ibs3a0zhw74zisc/visdial_1.0_val.zip?dl=0')
+            os.system('wget -O visdial_1.0_train.zip https://www.dropbox.com/s/ix8keeudqrd8hn8/visdial_1.0_train.zip?dl=0')
+            os.system('wget -O visdial_1.0_val.zip https://www.dropbox.com/s/ibs3a0zhw74zisc/visdial_1.0_val.zip?dl=0')
         elif args.version == '0.9':
             os.system('wget https://computing.ece.vt.edu/~abhshkdz/data/visdial/visdial_0.9_train.zip')
             os.system('wget https://computing.ece.vt.edu/~abhshkdz/data/visdial/visdial_0.9_val.zip')
-        os.system('wget https://www.dropbox.com/s/o7mucbre2zm7i5n/visdial_1.0_test.zip?dl=0')
+        os.system('wget -O visdial_1.0_test.zip https://www.dropbox.com/s/o7mucbre2zm7i5n/visdial_1.0_test.zip?dl=0')
 
         os.system('unzip visdial_%s_train.zip' % args.version)
         os.system('unzip visdial_%s_val.zip' % args.version)
         os.system('unzip visdial_1.0_test.zip')
 
-        args.input_json_train = 'visdial_%s_train.zip' % args.version
-        args.input_json_val = 'visdial_%s_val.zip' % args.version
-        args.input_json_test = 'visdial_1.0_test.zip'
+        args.input_json_train = 'visdial_%s_train.json' % args.version
+        args.input_json_val = 'visdial_%s_val.json' % args.version
+        args.input_json_test = 'visdial_1.0_test.json'
 
     print('Reading json...')
     data_train = json.load(open(args.input_json_train, 'r'))

--- a/data/prepro.py
+++ b/data/prepro.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
 
         args.input_json_train = 'visdial_%s_train.zip' % args.version
         args.input_json_val = 'visdial_%s_val.zip' % args.version
-        args.input_json_test = 'visdial_1.0_test.zip' % args.version
+        args.input_json_test = 'visdial_1.0_test.zip'
 
     print('Reading json...')
     data_train = json.load(open(args.input_json_train, 'r'))
@@ -243,20 +243,18 @@ if __name__ == "__main__":
     print('Encoding based on vocabulary...')
     data_train = encode_vocab(data_train, word2ind)
     data_val = encode_vocab(data_val, word2ind)
-    if args.train_split == 'trainval':
-        data_test = encode_vocab(data_test, word2ind)
+    data_test = encode_vocab(data_test, word2ind)
 
     print('Creating data matrices...')
     data_mats_train = create_data_mats(data_train, args, 'train')
     data_mats_val = create_data_mats(data_val, args, 'val')
+    data_mats_test = create_data_mats(data_test, args, 'test')
 
     if args.train_split == 'trainval':
         data_mats_trainval = {}
         for key in data_mats_train:
             data_mats_trainval[key] = np.concatenate((data_mats_train[key],
                                                       data_mats_val[key]), axis = 0)
-
-        data_mats_test = create_data_mats(data_test, args, 'test')
 
     print('Saving hdf5 to %s...' % args.output_h5)
     f = h5py.File(args.output_h5, 'w')
@@ -271,8 +269,8 @@ if __name__ == "__main__":
         for key in data_mats_trainval:
             f.create_dataset(key + '_train', dtype='uint32', data=data_mats_trainval[key])
 
-        for key in data_mats_test:
-            f.create_dataset(key + '_test', dtype='uint32', data=data_mats_test[key])
+    for key in data_mats_test:
+        f.create_dataset(key + '_test', dtype='uint32', data=data_mats_test[key])
     f.close()
 
     out = {}


### PR DESCRIPTION
- `-train_split train` has data matrices of all three splits - train, val and test.
- while `-download`ing, `-version` can be specified.