### PR TITLE
Generalize preprocessing of answer options across all splits.

### DIFF
--- a/data/prepro.py
+++ b/data/prepro.py
@@ -147,16 +147,16 @@ def create_data_mats(data, params, dtype):
     data_mats['ans_length'] = ans_length
 
     print("[%s] Creating options data matrices..." % data['split'])
-    options = np.zeros([num_threads, num_rounds, 100])
+    # options and answer_index are 1-indexed specifically for lua
+    options = np.ones([num_threads, num_rounds, 100])
     num_rounds_list = np.full(num_threads, 10)
 
     for i, dialog in enumerate(tqdm(data['data']['dialogs'])):
         for j in range(num_rounds):
-            # options and answer_index are 1-indexed specifically for lua
             num_rounds_list[i] = dialog['num_rounds']
             # v1.0 test does not have options for all dialog rounds
             if 'answer_options' in dialog['dialog'][j]:
-                options[i][j] = np.array(dialog['dialog'][j]['answer_options']) + 1
+                options[i][j] += np.array(dialog['dialog'][j]['answer_options'])
 
     data_mats['num_rounds'] = num_rounds_list
     data_mats['opt'] = options
@@ -285,7 +285,7 @@ if __name__ == "__main__":
     id2path = {}
     # NOTE: based on assumption that image_id is unique across all splits
     for image_path in tqdm(glob.iglob(os.path.join(args.image_root, '*', '*.jpg'))):
-        id2path[int(image_path[-12:-4])] = '/'.join(image_path.split('/')[1:])
+        id2path[int(image_path[-12:-4])] = '/'.join(image_path.split('/')[-2:])
 
     out['unique_img_train'] = get_image_ids(data_train, id2path)
     out['unique_img_val'] = get_image_ids(data_val, id2path)

--- a/data/prepro_utils.lua
+++ b/data/prepro_utils.lua
@@ -70,6 +70,8 @@ function extractFeatures(model, opt, ndims, preprocessFn)
     if opt.trainSplit == 'train' then
         imFeats = extractFeaturesSplit(model, opt, ndims, preprocessFn, 'val')
         h5File:write('/images_val', imFeats)
+        imFeats = extractFeaturesSplit(model, opt, ndims, preprocessFn, 'test')
+        h5File:write('/images_test', imFeats)
     elseif opt.trainSplit == 'trainval' then
         imFeats = extractFeaturesSplit(model, opt, ndims, preprocessFn, 'test')
         h5File:write('/images_test', imFeats)

--- a/dataloader.lua
+++ b/dataloader.lua
@@ -464,7 +464,7 @@ function dataloader.getIndexOption(self, inds, params, dtype)
     elseif params.decoder == 'disc' then
         local optInds = self[dtype .. '_opt']:index(1, inds)
         local indVector = optInds:view(-1)
-    
+
         local optionIn = self[dtype .. '_opt_list']:index(1, indVector)
 
         optionIn = optionIn:view(optInds:size(1), optInds:size(2), optInds:size(3), -1)

--- a/model.lua
+++ b/model.lua
@@ -174,7 +174,7 @@ function Model:retrieve(dataloader, dtype)
     local retrieval = {};
     local ranks = torch.totable(ranks:double());
     for i = 1, #dataloader['unique_img_'..dtype] do
-        for j = 1, 10 do
+        for j = 1, dataloader[dtype..'_num_rounds'][i] do
             table.insert(retrieval, {
                 image_id = dataloader['unique_img_'..dtype][i];
                 round_id = j;
@@ -230,7 +230,7 @@ function Model:predict(dataloader, dtype)
                 ranks = ranks[i][dataloader[dtype..'_num_rounds'][i]]
             })
         else
-            for j = 1, 10 do
+            for j = 1, dataloader[dtype..'_num_rounds'][i] do
                 table.insert(prediction, {
                     image_id = dataloader['unique_img_'..dtype][i];
                     round_id = j;


### PR DESCRIPTION
`v1.0` does not have answer options for all dialog rounds. To accommodate this, dataloader and model API were changed. This PR generalizes them back by imposing further abstraction within preprocessing script.

The schema of `visdial_data.h5`, `data_img.h5` would change after merge of this PR.